### PR TITLE
fix: `*.scheme.yaml` typo

### DIFF
--- a/en/guide/configurationOverride.md
+++ b/en/guide/configurationOverride.md
@@ -91,12 +91,12 @@ patch:
 
 ## Input method scheme configuration
 
-Next, let's take a look at the "Input Method Scheme Configuration". The global configuration of the scheme is `default.yaml` and `defalut.custom.yaml`; for local, taking the Mint input method as an example, `rime_mint.scheme.yaml` is A local configuration. The configuration of `default.yaml` can be overridden in `rime_mint.scheme.yaml`.
+Next, let's take a look at the "Input Method Scheme Configuration". The global configuration of the scheme is `default.yaml` and `defalut.custom.yaml`; for local, taking the Mint input method as an example, `rime_mint.schema.yaml` is A local configuration. The configuration of `default.yaml` can be overridden in `rime_mint.schema.yaml`.
 
-Relative to the scheme, you can also override the configuration of `rime_mint.scheme.yaml` based on `rime_mint.custom.yaml`.
+Relative to the scheme, you can also override the configuration of `rime_mint.schema.yaml` based on `rime_mint.custom.yaml`.
 
 So, the priority is:
-`rime_mint.custom.yaml > rime_mint.scheme.yaml > default.custom.yaml > default.yaml`
+`rime_mint.custom.yaml > rime_mint.schema.yaml > default.custom.yaml > default.yaml`
 
 Currently, the Mint input method does not specify `default.yaml`; it directly inherits the configuration that comes with Rime; on the contrary, it uses `default.custom.yaml` to override the global configuration. In the scheme input method, in the corresponding It's customizable.
 

--- a/en/guide/shortcutKeys.md
+++ b/en/guide/shortcutKeys.md
@@ -197,7 +197,7 @@ engine:
   processors:
     - lua_processor@*select_character # Determine the character by word
 ```
-So, if you want to use `[` and `]` for translation, taking Mint Pinyin (rime_mint.scheme.yaml file) as an example, you can modify the `key_binder` in it to the following configuration:
+So, if you want to use `[` and `]` for translation, taking Mint Pinyin (rime_mint.schema.yaml file) as an example, you can modify the `key_binder` in it to the following configuration:
 ```yarm
 key_binder:
   import_preset: default

--- a/zh/guide/configurationOverride.md
+++ b/zh/guide/configurationOverride.md
@@ -91,12 +91,12 @@ patch:
 
 ## 输入法方案配置
 
-接下来，我们看看「输入法方案配置」，方案的全局配置是`default.yaml`和`defalut.custom.yaml`；对于局部，以薄荷输入法为例，`rime_mint.scheme.yaml`就是一个局部配置。在`rime_mint.scheme.yaml`内可以覆写`default.yaml`的配置。
+接下来，我们看看「输入法方案配置」，方案的全局配置是`default.yaml`和`defalut.custom.yaml`；对于局部，以薄荷输入法为例，`rime_mint.schema.yaml`就是一个局部配置。在`rime_mint.schema.yaml`内可以覆写`default.yaml`的配置。
 
-相对于方案，你也可以基于`rime_mint.custom.yaml`去覆写`rime_mint.scheme.yaml`的配置。
+相对于方案，你也可以基于`rime_mint.custom.yaml`去覆写`rime_mint.schema.yaml`的配置。
 
 所以，优先级是:
-`rime_mint.custom.yaml > rime_mint.scheme.yaml > default.custom.yaml > default.yaml`
+`rime_mint.custom.yaml > rime_mint.schema.yaml > default.custom.yaml > default.yaml`
 
 目前，薄荷输入法并并没有指定`default.yaml`；是直接继承Rime自带的配置；相反，是使用`default.custom.yaml`覆写了全局的配置，在方案输入法内，在对其进行定制。
 

--- a/zh/guide/shortcutKeys.md
+++ b/zh/guide/shortcutKeys.md
@@ -201,7 +201,7 @@ engine:
   processors:
     - lua_processor@*select_character              # 以词定字
 ```
-所以，如果你想使用`[`和`]`来翻译，以薄荷拼音(rime_mint.scheme.yaml文件)为例，可以修改其中的`key_binder`为这样的配置：
+所以，如果你想使用`[`和`]`来翻页，以薄荷拼音(rime_mint.scheme.yaml文件)为例，可以修改其中的`key_binder`为这样的配置：
 ```yarm
 key_binder:
   import_preset: default

--- a/zh/guide/shortcutKeys.md
+++ b/zh/guide/shortcutKeys.md
@@ -201,7 +201,7 @@ engine:
   processors:
     - lua_processor@*select_character              # 以词定字
 ```
-所以，如果你想使用`[`和`]`来翻页，以薄荷拼音(rime_mint.scheme.yaml文件)为例，可以修改其中的`key_binder`为这样的配置：
+所以，如果你想使用`[`和`]`来翻页，以薄荷拼音(rime_mint.schema.yaml文件)为例，可以修改其中的`key_binder`为这样的配置：
 ```yarm
 key_binder:
   import_preset: default


### PR DESCRIPTION
the proper spelling should be `*.schema.yaml`.